### PR TITLE
Add status messages to app search prompt

### DIFF
--- a/src/components/Screen/Search.js
+++ b/src/components/Screen/Search.js
@@ -64,6 +64,16 @@ const Prompt = ({ allies, apps, siggedAlly, treaties, setPromptOpen, currentApp,
             ? <p className=" text-xs p-4">Please enter a valid <code>@p</code> to search for applications.</p>
             : <div className='flex flex-col space-y-2 w-full min-h-0 h-full self-start'>
                 {currentApp.value?.desk && <AppInfo apps={apps} currentApp={currentApp} setPromptOpen={setPromptOpen} />}
+                {!currentApp.value?.desk
+                    && ob.isValidPatp(siggedAlly)
+                    && (!allies.value?.[siggedAlly] || !allies.value?.[siggedAlly]?.length)
+                    && (
+                        <p className="p-4 text-xs text-center">
+                            No apps are available from {siggedAlly}.
+                        </p>
+                        )
+                }
+
                 {!currentApp.value?.desk && ob.isValidPatp(siggedAlly) && Object.values(allies.value?.[siggedAlly] || {})?.map((charge) => {
                     if (treaties.value?.[charge]) {
                         const app = treaties?.value?.[charge];

--- a/src/components/Screen/Search.js
+++ b/src/components/Screen/Search.js
@@ -64,6 +64,11 @@ const Prompt = ({ allies, apps, siggedAlly, treaties, setPromptOpen, currentApp,
             ? <p className=" text-xs p-4">Please enter a valid <code>@p</code> to search for applications.</p>
             : <div className='flex flex-col space-y-2 w-full min-h-0 h-full self-start'>
                 {currentApp.value?.desk && <AppInfo apps={apps} currentApp={currentApp} setPromptOpen={setPromptOpen} />}
+                {!currentApp.value?.desk && !ob.isValidPatp(siggedAlly) && (
+                    <p className="p-4 text-xs text-center">
+                        {query} is not a valid Urbit ship.
+                    </p>
+                )}
                 {!currentApp.value?.desk
                     && ob.isValidPatp(siggedAlly)
                     && (!allies.value?.[siggedAlly] || !allies.value?.[siggedAlly]?.length)


### PR DESCRIPTION
Adds one status message when no apps are available from an ally, and another when the query is not for a valid ship. 

![Screenshot 2022-11-21 at 6 03 12 PM](https://user-images.githubusercontent.com/57736583/203175538-8f8edea8-59be-4eb0-a5c3-6163079f327d.png)

![Screenshot 2022-11-21 at 6 03 20 PM](https://user-images.githubusercontent.com/57736583/203175568-a05f30fb-042b-43bf-9fed-edff9fd4c350.png)

