### PR TITLE
Remove deprecated .env instructions from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,12 @@
 ## Development
 
 ```bash
-cp .env.example .env ## set it to your ship and +code
 yarn install
 # Make sure that you aren't already running Scene.
 yarn dev ## spawns react + electron dev servers
 ```
+
+Log in to your local fake zod (use the correct port).
 
 ## Distribution
 


### PR DESCRIPTION
Having a `.env` file present breaks the dev build.

Ideally, the code that relies on the `.env` file would also be removed - but that's outside my scope for here.