### PR TITLE
Drag fixes

### DIFF
--- a/public/electron.js
+++ b/public/electron.js
@@ -21,6 +21,8 @@ function createWindow(dl_url) {
     mainWindow = new BrowserWindow({
         width: mainScreen.size.width,
         height: mainScreen.size.height,
+        minWidth: 1024,
+        minHeight: 768,
         backgroundColor: 'black',
         // Set the path of an additional "preload" script that can be used to
         // communicate between node-land and browser-land.

--- a/public/electron.js
+++ b/public/electron.js
@@ -13,6 +13,8 @@ require("dotenv").config();
 const { default: installExtension, REACT_DEVELOPER_TOOLS } = require('electron-devtools-installer');
 const { autoUpdater } = require("electron-updater");
 
+const WIN_OR_MAC = process.platform === 'darwin' || process.platform === 'win32';
+
 let mainWindow;
 let dl_url;
 // Create the native browser window.
@@ -21,8 +23,8 @@ function createWindow(dl_url) {
     mainWindow = new BrowserWindow({
         width: mainScreen.size.width,
         height: mainScreen.size.height,
-        minWidth: 1024,
-        minHeight: 768,
+        minWidth: WIN_OR_MAC ? 800 : undefined,
+        minHeight: WIN_OR_MAC ? 600 : undefined,
         backgroundColor: 'black',
         // Set the path of an additional "preload" script that can be used to
         // communicate between node-land and browser-land.

--- a/src/App.js
+++ b/src/App.js
@@ -118,7 +118,7 @@ function App() {
         launchOpen={{ value: launchOpen, set: setLaunchOpen }}
         windows={{ value: windows, set: setWindows }}
       >
-        {launchOpen && <Launchpad
+        <Launchpad
           apps={apps}
           launchOpen={{ value: launchOpen, set: setLaunchOpen }}
           focusByCharge={focusByCharge}>
@@ -127,7 +127,13 @@ function App() {
             treaties={{ value: treaties, set: setTreaties }}
             apps={apps}
           />
-        </Launchpad>}
+        </Launchpad>
+        <Dock
+          apps={apps}
+          launchOpen={{ value: launchOpen, set: setLaunchOpen }}
+          windows={{ value: windows, set: setWindows }}
+          focusByCharge={focusByCharge}
+        />
       </Screen>
       <PlanetMenu
         visible={{ value: showPlanetMenu, set: setShowPlanetMenu }}
@@ -145,12 +151,6 @@ function App() {
       <Notifications
         visible={{ value: showNotifs, set: setShowNotifs }}
         charges={apps.charges}
-        focusByCharge={focusByCharge}
-      />
-      <Dock
-        apps={apps}
-        launchOpen={{ value: launchOpen, set: setLaunchOpen }}
-        windows={{ value: windows, set: setWindows }}
         focusByCharge={focusByCharge}
       />
     </div>

--- a/src/App.js
+++ b/src/App.js
@@ -100,7 +100,7 @@ function App() {
 
   return (
     <div
-      className="bg-[#e4e4e4] h-screen w-screen flex flex-col absolute"
+      className="bg-[#e4e4e4] h-screen w-screen flex flex-col absolute overflow-hidden"
       style={{
         backgroundImage: bgImage ? `url(${bgImage})` : "url('hallstatt.jpg')",
         backgroundSize: 'cover',

--- a/src/components/Dock.js
+++ b/src/components/Dock.js
@@ -3,7 +3,7 @@ import LaunchpadIcon from "./icons/launchpad";
 
 export default function Dock({ windows, focusByCharge, launchOpen }) {
   return (
-    <div className="bg-[rgba(0,0,0,0.7)] backdrop-blur-sm text-white w-fit self-center items-center p-2 flex rounded-t-md shadow-sm shadow-[rgba(0,0,0,0.15)] border border-[rgba(0,0,0,0.15)] position-absolute">
+    <div className="bg-[rgba(0,0,0,0.7)] backdrop-blur-sm text-white w-fit self-center items-center p-2 flex rounded-t-md shadow-sm shadow-[rgba(0,0,0,0.15)] border border-[rgba(0,0,0,0.15)] z-[1000]">
       {windows.value.map((charge) => {
         return (
           <Tippy key={charge.title} content={charge.title}>

--- a/src/components/Dock.js
+++ b/src/components/Dock.js
@@ -3,7 +3,7 @@ import LaunchpadIcon from "./icons/launchpad";
 
 export default function Dock({ windows, focusByCharge, launchOpen }) {
   return (
-    <div className="bg-[rgba(0,0,0,0.7)] backdrop-blur-sm text-white w-fit self-center items-center p-2 flex rounded-t-md shadow-sm shadow-[rgba(0,0,0,0.15)] border border-[rgba(0,0,0,0.15)]">
+    <div className="bg-[rgba(0,0,0,0.7)] backdrop-blur-sm text-white w-fit self-center items-center p-2 flex rounded-t-md shadow-sm shadow-[rgba(0,0,0,0.15)] border border-[rgba(0,0,0,0.15)] position-absolute">
       {windows.value.map((charge) => {
         return (
           <Tippy key={charge.title} content={charge.title}>

--- a/src/components/Dock.js
+++ b/src/components/Dock.js
@@ -1,27 +1,33 @@
-import Tippy from '@tippyjs/react';
-import LaunchpadIcon from "./icons/launchpad"
+import Tippy from "@tippyjs/react";
+import LaunchpadIcon from "./icons/launchpad";
 
 export default function Dock({ windows, focusByCharge, launchOpen }) {
-    return <div className="bg-[rgba(0,0,0,0.7)] backdrop-blur-sm text-white w-fit self-center items-center p-2 flex rounded-t-md shadow-sm shadow-[rgba(0,0,0,0.15)] border border-[rgba(0,0,0,0.15)]">
-        {windows.value.map((charge) => {
-            return <Tippy key={charge.title} content={charge.title}>
-                <div
-                    className="h-14 w-14 rounded-xl overflow-hidden mx-2 cursor-pointer hover:brightness-110"
-                    style={{ backgroundColor: charge.color }}
-                    key={charge.title}
-                    onClick={() => focusByCharge(charge)}
-                >
-                    {charge?.image && <img className="h-14 w-14" src={charge.image} />}
-                </div>
-            </Tippy>
-        })}
-        <Tippy key="launch" content="Launchpad">
-            <a
-                className="cursor-pointer hover:brightness-110 px-[11px] py-[13px]"
-                onClick={() => launchOpen.set(!launchOpen.value)}
+  return (
+    <div className="bg-[rgba(0,0,0,0.7)] backdrop-blur-sm text-white w-fit self-center items-center p-2 flex rounded-t-md shadow-sm shadow-[rgba(0,0,0,0.15)] border border-[rgba(0,0,0,0.15)]">
+      {windows.value.map((charge) => {
+        return (
+          <Tippy key={charge.title} content={charge.title}>
+            <div
+              className="h-14 w-14 rounded-xl overflow-hidden mx-2 cursor-pointer hover:brightness-110"
+              style={{ backgroundColor: charge.color }}
+              key={charge.title}
+              onClick={() => focusByCharge(charge)}
             >
-                <LaunchpadIcon />
-            </a>
-        </Tippy>
+              {charge?.image && (
+                <img className="h-14 w-14" src={charge.image} />
+              )}
+            </div>
+          </Tippy>
+        );
+      })}
+      <Tippy key="launch" content="Launchpad">
+        <a
+          className="cursor-pointer hover:brightness-110 px-[11px] py-[13px]"
+          onClick={() => launchOpen.set(!launchOpen.value)}
+        >
+          <LaunchpadIcon />
+        </a>
+      </Tippy>
     </div>
+  );
 }

--- a/src/components/Notifications.js
+++ b/src/components/Notifications.js
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useMemo } from 'react';
 import _ from 'lodash';
 import { harkBinToId } from '@urbit/api';
 import CloseIcon from './icons/close';
@@ -22,6 +22,24 @@ const Notifications = props => {
     lastVisible.current = visible.value;
   }, [visible]);
 
+  const sortedUnseen = useMemo(() =>
+    Object.values(unseen)
+      .sort((a, b) => b.time - a.time)
+      .filter(n => !!n?.body?.[0])
+      .filter(n => !!charges?.[n.bin.place.desk])
+      .map(n => ([n, charges[n.bin.place.desk]]))
+      .filter(([n, charge]) => charge?.title !== 'System'),
+  [charges, unseen]);
+  const sortedSeen = useMemo(() => 
+    Object.values(seen)
+    .sort((a, b) => b.time - a.time)
+    .filter(n => !!n?.body?.[0])
+    .filter(n => !!charges?.[n.bin.place.desk])
+    .map(n => ([n, charges[n.bin.place.desk]]))
+    .filter(([n, charge]) => charge?.title !== 'System'),
+  [charges, seen]);
+
+
   return (
     <div
       id="notifications"
@@ -33,49 +51,31 @@ const Notifications = props => {
             <p>No notifications</p>
           </div>
         )}
-        {Object.values(unseen)
-          .sort((a, b) => b.time - a.time)
-          .filter(n => !!n?.body?.[0])
-          .filter(n => !!charges?.[n.bin.place.desk])
-          .map(n => ([n, charges[n.bin.place.desk]]))
-          .filter(([n, charge]) => charge?.title !== 'System')
-          .map(([n, charge], idx) => (
-            <Notification {...{
-              key: `unseen-${idx}`,
-              className: 'unseen',
-              notification: n,
-              charge,
-              lid: { unseen: null },
-              onClick: () => {
-                focusByCharge(charge);
-                visible.set(false);
-              },
-            }}>
-              Unseen Notification {idx}
-            </Notification>
-          ))
-        }
-        {Object.values(seen)
-          .sort((a, b) => b.time - a.time)
-          .filter(n => !!n?.body?.[0])
-          .filter(n => !!charges?.[n.bin.place.desk])
-          .map(n => ([n, charges[n.bin.place.desk]]))
-          .filter(([n, charge]) => charge?.title !== 'System')
-          .map(([n, charge], idx) => (
-            <Notification {...{
-              key: `seen-${idx}`,
-              notification: n,
-              charge,
-              lid: { seen: null },
-              onClick: () => {
-                focusByCharge(charge)
-                visible.set(false);
-              },
-            }}>
-              Seen Notification {idx}
-            </Notification>
-          ))
-        }
+        {sortedUnseen.map(([n, charge], idx) => (
+          <Notification {...{
+            key: `unseen-${idx}`,
+            className: 'unseen',
+            notification: n,
+            charge,
+            lid: { unseen: null },
+            onClick: () => {
+              focusByCharge(charge);
+              visible.set(false);
+            },
+          }}/>
+        ))}
+        {sortedSeen.map(([n, charge], idx) => (
+          <Notification {...{
+            key: `seen-${idx}`,
+            notification: n,
+            charge,
+            lid: { seen: null },
+            onClick: () => {
+              focusByCharge(charge)
+              visible.set(false);
+            },
+          }}/>
+        ))}
       </section>
     </div>
   );

--- a/src/components/Screen.js
+++ b/src/components/Screen.js
@@ -8,7 +8,7 @@ export default function Screen({
   children,
 }) {
   return (
-    <div className="grow">
+    <div className="grow flex flex-col justify-end items-center">
       {children}
       {windows.value.map((win, index) => (
         <Window

--- a/src/components/Screen.js
+++ b/src/components/Screen.js
@@ -1,4 +1,5 @@
 import Window from "./Screen/Window";
+import { screenPadding } from '../lib/constants';
 
 export default function Screen({
   windows,
@@ -8,7 +9,16 @@ export default function Screen({
   children,
 }) {
   return (
-    <div className="grow flex flex-col justify-end items-center">
+    <div
+      className="grow flex flex-col justify-end items-center"
+      style={{
+        // enlarges this bit without changing position of content. 
+        marginInline: `-${screenPadding.inline}px`,
+        paddingInline: `${screenPadding.inline}px`,
+        marginBottom: `-${screenPadding.bottom}px`,
+        paddingBottom: `${screenPadding.bottom}px`,
+      }}
+    >
       {children}
       {windows.value.map((win, index) => (
         <Window

--- a/src/components/Screen.js
+++ b/src/components/Screen.js
@@ -1,17 +1,26 @@
-import Window from './Screen/Window';
+import Window from "./Screen/Window";
 
-export default function Screen({ windows, selectedWindow, hiddenWindow, launchOpen, children }) {
-    return <div className="grow">
-        {children}
-        {windows.value.map((win, index) => <Window
-            key={win.title}
-            win={win}
-            launchOpen={launchOpen}
-            index={index}
-            windows={windows}
-            selectedWindow={selectedWindow}
-            hiddenWindow={hiddenWindow}
-        />)
-        }
+export default function Screen({
+  windows,
+  selectedWindow,
+  hiddenWindow,
+  launchOpen,
+  children,
+}) {
+  return (
+    <div className="grow">
+      {children}
+      {windows.value.map((win, index) => (
+        <Window
+          key={win.title}
+          win={win}
+          launchOpen={launchOpen}
+          index={index}
+          windows={windows}
+          selectedWindow={selectedWindow}
+          hiddenWindow={hiddenWindow}
+        />
+      ))}
     </div>
+  );
 }

--- a/src/components/Screen/Launchpad.js
+++ b/src/components/Screen/Launchpad.js
@@ -9,19 +9,18 @@ export default function Launchpad({
   launchOpen,
 }) {
   const wrapperRef = useRef(null);
-  useOutsideAlerter(wrapperRef, () => launchOpen.set(!launchOpen.value));
+  useOutsideAlerter(wrapperRef, () => launchOpen.set(false));
   return (
-    <div className="w-full h-full z-[1000] flex justify-center items-center transition-all">
-      <div
-        className={cn(
-          "bg-[rgba(0,0,0,0.7)] shadow-md shadow-[rgba(0,0,0,0.1)] w-full h-full max-w-[1024px] max-h-[80vh] z-[1000] rounded-xl m-4 flex flex-col items-center justify-center backdrop-blur-sm transition-all ease-in-out p-6",
-          { "opacity-0 fade-in": launchOpen.value === true }
-        )}
-        ref={wrapperRef}
-      >
-        {children}
-        <div className="grow overflow-y-auto grid md:grid-cols-3 xl:grid-cols-4 gap-8">
-          {Object.entries(apps?.charges || {})
+    <div
+      className={cn(
+      "bg-[rgba(0,0,0,0.7)] shadow-md shadow-[rgba(0,0,0,0.1)] w-full h-full max-w-[1024px] max-h-[80vh] z-[1000] rounded-xl m-4 flex flex-col items-center justify-center backdrop-blur-sm transition-all ease-in-out p-6 grow",
+        { "opacity-0 fade-in": launchOpen.value, 'invisible': !launchOpen.value }
+      )}
+    ref={wrapperRef}
+    >
+      {children}
+      <div className="grow overflow-y-auto grid md:grid-cols-3 xl:grid-cols-4 gap-8">
+        {Object.entries(apps?.charges || {})
             .sort((a, b) =>
               a[1].title.toLowerCase().localeCompare(b[1].title.toLowerCase())
             )
@@ -51,7 +50,6 @@ export default function Launchpad({
                 <p>{charge.title}</p>
               </div>
             ))}
-        </div>
       </div>
     </div>
   );

--- a/src/components/Screen/Window.js
+++ b/src/components/Screen/Window.js
@@ -33,6 +33,8 @@ export const Window = ({
         y: (index + 1) * 100,
         width: 800,
         height: 600,
+        minWidth: 800,
+        minHeight: 600,
       }}
     >
       <div className="w-full h-full flex flex-col bg-[#EEE] cursor-default">

--- a/src/components/Screen/Window.js
+++ b/src/components/Screen/Window.js
@@ -4,7 +4,7 @@ import cn from "classnames";
 import CloseIcon from "../icons/close";
 import MinimizeIcon from "../icons/minimize";
 import RefreshIcon from "../icons/refresh";
-import { screenPadding } from '../../lib/constants';
+import { screenPadding } from "../../lib/constants";
 
 export const Window = ({
   win,
@@ -15,6 +15,7 @@ export const Window = ({
   hiddenWindow,
 }) => {
   const [key, setKey] = useState(0);
+  const [drag, setDrag] = useState(false);
   const href =
     "glob" in win.chad
       ? `${window.url}/apps/${win.href.glob.base}`
@@ -27,6 +28,8 @@ export const Window = ({
         zIndex: ([...selectedWindow.value].reverse().indexOf(win) + 1) * 10,
         visibility: hiddenWindow.value.includes(win) ? "hidden" : "visible",
       }}
+      onDragStart={() => setDrag(true)}
+      onDragStop={() => setDrag(false)}
       default={{
         // add 600 px to accommodate padding for offscreen scrolling
         x: (index + 1) * 100 + screenPadding.inline,
@@ -91,6 +94,7 @@ export const Window = ({
           onClick={() => launchOpen.set(false)}
         >
           <Frame
+            dragged={drag}
             selectedWindow={selectedWindow}
             win={win}
             launchOpen={launchOpen}
@@ -104,13 +108,22 @@ export const Window = ({
   );
 };
 
-const Frame = ({ selectedWindow, launchOpen, win, href, title, keyName }) => {
+const Frame = ({
+  dragged,
+  selectedWindow,
+  launchOpen,
+  win,
+  href,
+  title,
+  keyName,
+}) => {
   return (
     <iframe
       className={cn("w-full h-full bg-white min-h-0 select-none", {
         "pointer-events-none":
           selectedWindow.value?.[0]?.title !== win.title ||
-          launchOpen.value === true,
+          launchOpen.value ||
+          dragged,
       })}
       src={href}
       title={title}

--- a/src/components/Screen/Window.js
+++ b/src/components/Screen/Window.js
@@ -4,6 +4,7 @@ import cn from "classnames";
 import CloseIcon from "../icons/close";
 import MinimizeIcon from "../icons/minimize";
 import RefreshIcon from "../icons/refresh";
+import { screenPadding } from '../../lib/constants';
 
 export const Window = ({
   win,
@@ -27,7 +28,8 @@ export const Window = ({
         visibility: hiddenWindow.value.includes(win) ? "hidden" : "visible",
       }}
       default={{
-        x: (index + 1) * 100,
+        // add 600 px to accommodate padding for offscreen scrolling
+        x: (index + 1) * 100 + screenPadding.inline,
         y: (index + 1) * 100,
         width: 800,
         height: 600,

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -5,3 +5,8 @@ const testnet_publicKey = "LS0tLS1CRUdJTiBQR1AgUFVCTElDIEtFWSBCTE9DSy0tLS0tCgptU
 export const publicKey = process.env.CIRCLE_PUBLIC_KEY || testnet_publicKey;
 
 export const shipHost = `third.earth`;
+
+export const screenPadding = {
+  bottom: 450,
+  inline: 600,
+}


### PR DESCRIPTION
Fixes janky vertical dragging.

Sets minimum dimensions for the Scene window at 1024x768, and for individual apps at 800x600.

Expands the area windows can be dragged through, such that the smallest sized windows can be hidden but not completely lost. 

Also memoized sorting and prepping notifications, and prettier in a few spots. 

don't make fun of me for this screencap 

![2022-11-30 17 01 56](https://user-images.githubusercontent.com/57736583/204918369-6ced4665-e5c9-46bf-89e4-eeb55efa8858.gif)


- memoize notification ordering
- prettier
- improve draggable area
- expand draggable area
- add minwidth and minheight for windows
- fix janky vertical dragging
- set window minimum height
