### PR TITLE
Add loading indicator in treaty search

### DIFF
--- a/src/components/Screen/Search.js
+++ b/src/components/Screen/Search.js
@@ -1,173 +1,214 @@
-import { allyShip, deSig, docketInstall } from '@urbit/api';
-import { useEffect, useState } from 'react';
-import ob from 'urbit-ob';
-import { api } from '../../state/api';
+import { allyShip, deSig, docketInstall } from "@urbit/api";
+import { useEffect, useState } from "react";
+import ob from "urbit-ob";
+import { api } from "../../state/api";
 import { getTreaties } from "../../state/treaties";
 
 export default function Search({ allies, treaties, apps }) {
-    const [query, setQuery] = useState("");
-    const [promptOpen, setPromptOpen] = useState(false);
-    const [currentApp, setCurrentApp] = useState({});
-    const siggedAlly = `~${deSig(query)}`;
+  const [query, setQuery] = useState("");
+  const [promptOpen, setPromptOpen] = useState(false);
+  const [currentApp, setCurrentApp] = useState({});
+  const siggedAlly = `~${deSig(query)}`;
 
-    // useEffect(() => {
-    //     if (allies.value?.[siggedAlly]?.length > 0 && !treaties?.[allies.value?.[siggedAlly][0]]) {
-    //         searchFetch(treaties, getTreaties(siggedAlly));
-    //     }
-    // }, [allies, siggedAlly, treaties]);
+  // useEffect(() => {
+  //     if (allies.value?.[siggedAlly]?.length > 0 && !treaties?.[allies.value?.[siggedAlly][0]]) {
+  //         searchFetch(treaties, getTreaties(siggedAlly));
+  //     }
+  // }, [allies, siggedAlly, treaties]);
 
-    return <div className="relative w-full max-w-md flex items-center justify-center"><input
+  return (
+    <div className="relative w-full max-w-md flex items-center justify-center">
+      <input
         type="text"
         placeholder="Search for providers..."
         className="rounded-xl my-4 py-1 px-2 bg-[rgba(0,0,0,0.1)] text-white"
         autoCorrect={"false"}
         onFocus={() => setPromptOpen(true)}
         onBlur={() => {
-            if (query === "") {
-                setPromptOpen(false);
-            }
+          if (query === "") {
+            setPromptOpen(false);
+          }
         }}
         onChange={(e) => setQuery(e.target.value)}
         onKeyDown={(e) => {
-            if (e.key === "Enter") {
-                e.preventDefault();
-                if (ob.isValidPatp(siggedAlly)) {
-                    if (allies.value?.[siggedAlly]) {
-                        searchFetch(treaties, getTreaties(siggedAlly));
-                    } else {
-                        api.poke(allyShip(siggedAlly)).then(() => {
-                            setTimeout(() => {
-                                searchFetch(treaties, getTreaties(siggedAlly));
-                            }, 5000)
-                        });
-                    }
-                }
+          if (e.key === "Enter") {
+            e.preventDefault();
+            if (ob.isValidPatp(siggedAlly)) {
+              if (allies.value?.[siggedAlly]) {
+                searchFetch(treaties, getTreaties(siggedAlly));
+              } else {
+                api.poke(allyShip(siggedAlly)).then(() => {
+                  setTimeout(() => {
+                    searchFetch(treaties, getTreaties(siggedAlly));
+                  }, 5000);
+                });
+              }
             }
+          }
         }}
         value={query}
-    />
-        {promptOpen && <Prompt
-            allies={allies}
-            apps={apps}
-            siggedAlly={siggedAlly}
-            treaties={treaties}
-            setPromptOpen={setPromptOpen}
-            currentApp={{ value: currentApp, set: setCurrentApp }}
-            query={query}
-        />}
-    </div >
-}
-
-const Prompt = ({ allies, apps, siggedAlly, treaties, setPromptOpen, currentApp, query }) => {
-    return <div className="bg-black text-white absolute top-14 self-center w-full rounded-xl shadow-md shadow-[rgba(0,0,0,0.1)] p-4 flex justify-center items-center min-h-[200px] max-h-[500px] overflow-y-auto">
-        {query === ""
-            ? <p className=" text-xs p-4">Please enter a valid <code>@p</code> to search for applications.</p>
-            : <div className='flex flex-col space-y-2 w-full min-h-0 h-full self-start'>
-                {currentApp.value?.desk && <AppInfo apps={apps} currentApp={currentApp} setPromptOpen={setPromptOpen} />}
-                {!currentApp.value?.desk && !ob.isValidPatp(siggedAlly) && (
-                    <p className="p-4 text-xs text-center">
-                        {query} is not a valid Urbit ship.
-                    </p>
-                )}
-                {!currentApp.value?.desk
-                    && ob.isValidPatp(siggedAlly)
-                    && (!allies.value?.[siggedAlly] || !allies.value?.[siggedAlly]?.length)
-                    && (
-                        <p className="p-4 text-xs text-center">
-                            No apps are available from {siggedAlly}.
-                        </p>
-                        )
-                }
-
-                {!currentApp.value?.desk && ob.isValidPatp(siggedAlly) && Object.values(allies.value?.[siggedAlly] || {})?.map((charge) => {
-                    if (treaties.value?.[charge]) {
-                        const app = treaties?.value?.[charge];
-                        return <div
-                            className="p-2 hover:bg-[rgba(255,255,255,0.1)] rounded-xl flex justify-between w-full items-center cursor-pointer"
-                            key={app.desk}
-                            onClick={() => {
-                                setPromptOpen(true);
-                                currentApp.set(app);
-                            }}>
-                            <div className='flex space-x-4'>
-                                <div
-                                    className="h-14 w-14 rounded-xl overflow-hidden mx-2"
-                                    style={{ backgroundColor: app.color }}
-                                    key={app.title}
-                                >
-                                    {app?.image?.startsWith("http")
-                                        ? <img className="h-14 w-14" src={app.image} />
-                                        : null}
-                                </div>
-                                <div className="flex flex-col space-y-1">
-                                    <p>{app.title || app.desk}</p>
-                                    {app.info !== '' && <p className="truncate w-full">{app.info}</p>}
-                                </div>
-                            </div>
-                        </div>
-                    } else return null
-                })}
-            </div>}
+      />
+      {promptOpen && (
+        <Prompt
+          allies={allies}
+          apps={apps}
+          siggedAlly={siggedAlly}
+          treaties={treaties}
+          setPromptOpen={setPromptOpen}
+          currentApp={{ value: currentApp, set: setCurrentApp }}
+          query={query}
+        />
+      )}
     </div>
+  );
 }
+
+const Prompt = ({
+  allies,
+  apps,
+  siggedAlly,
+  treaties,
+  setPromptOpen,
+  currentApp,
+  query,
+}) => {
+  return (
+    <div className="bg-black text-white absolute top-14 self-center w-full rounded-xl shadow-md shadow-[rgba(0,0,0,0.1)] p-4 flex justify-center items-center min-h-[200px] max-h-[500px] overflow-y-auto">
+      {query === "" ? (
+        <p className=" text-xs p-4">
+          Please enter a valid <code>@p</code> to search for applications.
+        </p>
+      ) : (
+        <div className="flex flex-col space-y-2 w-full min-h-0 h-full self-start">
+          {currentApp.value?.desk && (
+            <AppInfo
+              apps={apps}
+              currentApp={currentApp}
+              setPromptOpen={setPromptOpen}
+            />
+          )}
+          {!currentApp.value?.desk && !ob.isValidPatp(siggedAlly) && (
+            <p className="p-4 text-xs text-center">
+              {query} is not a valid Urbit ship.
+            </p>
+          )}
+          {!currentApp.value?.desk &&
+            ob.isValidPatp(siggedAlly) &&
+            (!allies.value?.[siggedAlly] ||
+              !allies.value?.[siggedAlly]?.length) && (
+              <p className="p-4 text-xs text-center">
+                No apps are available from {siggedAlly}.
+              </p>
+            )}
+
+          {!currentApp.value?.desk &&
+            ob.isValidPatp(siggedAlly) &&
+            Object.values(allies.value?.[siggedAlly] || {})?.map((charge) => {
+              if (treaties.value?.[charge]) {
+                const app = treaties?.value?.[charge];
+                return (
+                  <div
+                    className="p-2 hover:bg-[rgba(255,255,255,0.1)] rounded-xl flex justify-between w-full items-center cursor-pointer"
+                    key={app.desk}
+                    onClick={() => {
+                      setPromptOpen(true);
+                      currentApp.set(app);
+                    }}
+                  >
+                    <div className="flex space-x-4">
+                      <div
+                        className="h-14 w-14 rounded-xl overflow-hidden mx-2"
+                        style={{ backgroundColor: app.color }}
+                        key={app.title}
+                      >
+                        {app?.image?.startsWith("http") ? (
+                          <img className="h-14 w-14" src={app.image} />
+                        ) : null}
+                      </div>
+                      <div className="flex flex-col space-y-1">
+                        <p>{app.title || app.desk}</p>
+                        {app.info !== "" && (
+                          <p className="truncate w-full">{app.info}</p>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                );
+              } else return null;
+            })}
+        </div>
+      )}
+    </div>
+  );
+};
 
 const AppInfo = ({ currentApp, apps, setPromptOpen }) => {
-    const app = currentApp.value;
-    return <div className="min-h-0 min-w-0 w-full h-full flex flex-col space-y-2">
+  const app = currentApp.value;
+  return (
+    <div className="min-h-0 min-w-0 w-full h-full flex flex-col space-y-2">
+      <a
+        className="cursor-pointer font-bold"
+        onClick={() => currentApp.set({})}
+      >
+        ← Back
+      </a>
+      <div className="flex items-center space-x-4 p-2">
+        <div
+          className="h-16 w-16 rounded-xl overflow-hidden mx-2"
+          style={{ backgroundColor: app.color }}
+          key={app.title}
+        >
+          {app?.image?.startsWith("http") ? (
+            <img className="h-16 w-16" src={app.image} />
+          ) : null}
+        </div>
+        <div className="flex flex-col space-y-1">
+          <p>{app.title || app.desk}</p>
+          {app.info !== "" && <p className="truncate w-full">{app.info}</p>}
+        </div>
+      </div>
+      {!apps.charges?.[app.desk] && (
+        <button
+          className="bg-blue-500 text-white"
+          onClick={() => {
+            api.poke(docketInstall(app.ship, app.desk));
+            setPromptOpen(false);
+          }}
+        >
+          Install app
+        </button>
+      )}
+      <div className="flex justify-between">
+        <p className="font-bold">Version</p>
+        <p>{app.version}</p>
+      </div>
+      <div className="flex justify-between">
+        <p className="font-bold">Latest hash</p>
+        <p className="font-mono">{app.hash.split(".").slice(-1)}</p>
+      </div>
+      <div className="flex justify-between">
+        <p className="font-bold">License</p>
+        <p>{app.license}</p>
+      </div>
+      <div className="flex justify-between">
+        <p className="font-bold">Host</p>
+        <p className="font-mono">{app.ship}</p>
+      </div>
+      <div className="flex justify-between">
+        <p className="font-bold">Website</p>
         <a
-            className="cursor-pointer font-bold"
-            onClick={() => currentApp.set({})}
+          className="min-w-0 truncate block border-b"
+          href={app.website}
+          target="_blank"
         >
-            ← Back
+          {app.website}
         </a>
-        <div className="flex items-center space-x-4 p-2">
-            <div
-                className="h-16 w-16 rounded-xl overflow-hidden mx-2"
-                style={{ backgroundColor: app.color }}
-                key={app.title}
-            >
-                {app?.image?.startsWith("http")
-                    ? <img className="h-16 w-16" src={app.image} />
-                    : null}
-            </div>
-            <div className='flex flex-col space-y-1'>
-                <p>{app.title || app.desk}</p>
-                {app.info !== '' && <p className="truncate w-full">{app.info}</p>}
-            </div>
-        </div>
-        {!apps.charges?.[app.desk] && <button
-            className="bg-blue-500 text-white"
-            onClick={() => {
-                api.poke(docketInstall(app.ship, app.desk))
-                setPromptOpen(false)
-            }}
-        >
-            Install app
-        </button>}
-        <div className="flex justify-between">
-            <p className="font-bold">Version</p>
-            <p>{app.version}</p>
-        </div>
-        <div className="flex justify-between">
-            <p className="font-bold">Latest hash</p>
-            <p className="font-mono">{app.hash.split(".").slice(-1)}</p>
-        </div>
-        <div className="flex justify-between">
-            <p className="font-bold">License</p>
-            <p>{app.license}</p>
-        </div>
-        <div className="flex justify-between">
-            <p className="font-bold">Host</p>
-            <p className="font-mono">{app.ship}</p>
-        </div>
-        <div className="flex justify-between">
-            <p className="font-bold">Website</p>
-            <a className="min-w-0 truncate block border-b" href={app.website} target="_blank">{app.website}</a>
-        </div>
+      </div>
     </div>
-}
+  );
+};
 
 async function searchFetch(reducer, action) {
-    const fetchedItem = await action;
-    return reducer.set(fetchedItem)
+  const fetchedItem = await action;
+  return reducer.set(fetchedItem);
 }

--- a/src/components/Screen/Search.js
+++ b/src/components/Screen/Search.js
@@ -8,6 +8,7 @@ export default function Search({ allies, treaties, apps }) {
   const [query, setQuery] = useState("");
   const [promptOpen, setPromptOpen] = useState(false);
   const [currentApp, setCurrentApp] = useState({});
+  const [loading, setLoading] = useState(false);
   const siggedAlly = `~${deSig(query)}`;
 
   // useEffect(() => {
@@ -34,12 +35,15 @@ export default function Search({ allies, treaties, apps }) {
           if (e.key === "Enter") {
             e.preventDefault();
             if (ob.isValidPatp(siggedAlly)) {
+              setLoading(true);
               if (allies.value?.[siggedAlly]) {
-                searchFetch(treaties, getTreaties(siggedAlly));
+                searchFetch(treaties, getTreaties(siggedAlly))
+                  .then(() => setLoading(false));
               } else {
                 api.poke(allyShip(siggedAlly)).then(() => {
                   setTimeout(() => {
-                    searchFetch(treaties, getTreaties(siggedAlly));
+                    searchFetch(treaties, getTreaties(siggedAlly))
+                      .then(() => setLoading(false));
                   }, 5000);
                 });
               }
@@ -57,6 +61,7 @@ export default function Search({ allies, treaties, apps }) {
           setPromptOpen={setPromptOpen}
           currentApp={{ value: currentApp, set: setCurrentApp }}
           query={query}
+          loading={loading}
         />
       )}
     </div>
@@ -71,6 +76,7 @@ const Prompt = ({
   setPromptOpen,
   currentApp,
   query,
+  loading,
 }) => {
   return (
     <div className="bg-black text-white absolute top-14 self-center w-full rounded-xl shadow-md shadow-[rgba(0,0,0,0.1)] p-4 flex justify-center items-center min-h-[200px] max-h-[500px] overflow-y-auto">
@@ -98,6 +104,12 @@ const Prompt = ({
               !allies.value?.[siggedAlly]?.length) && (
               <p className="p-4 text-xs text-center">
                 No apps are available from {siggedAlly}.
+                <br />
+                {loading ? (
+                  <span>Loading...</span>
+                ) : (
+                  <span>Press Enter to search again.</span>
+                )}
               </p>
             )}
 


### PR DESCRIPTION
Adds a loading state to the treaty search prompt. 

![Screenshot 2022-12-06 at 2 07 21 PM](https://user-images.githubusercontent.com/57736583/206001851-d70680b2-a674-4d52-9efa-2c3e00165662.png)

![Screenshot 2022-12-06 at 2 07 31 PM](https://user-images.githubusercontent.com/57736583/206001828-eed28de0-250e-4735-86be-4e528186ed33.png)

There's one quirk: If there are apps available from the given patp, sometimes you still have to hit enter before they'll show: 

![image](https://user-images.githubusercontent.com/57736583/206005446-ba91800b-cecb-47eb-9ff8-95c6da00153c.png)

I tried adding something here but all of my efforts were rebutted: I always ended up showing more than one of these status messages at the same time, because the condition to check is so complex. 

Am torn by this. It's flaky, which I hate, but the fact is that the Garden has the same problem. 