### PR TITLE
allies: add 'add' reducers for allies to prevent setting undefined

### DIFF
--- a/src/state/allies.js
+++ b/src/state/allies.js
@@ -1,6 +1,4 @@
 export const allyReducer = (state, action) => {
-    console.log(state);
-    console.log(action);
     switch (Object.keys(action)[0]) {
         case "ini":
             return action.ini;

--- a/src/state/allies.js
+++ b/src/state/allies.js
@@ -1,10 +1,16 @@
 export const allyReducer = (state, action) => {
+    console.log(state);
+    console.log(action);
     switch (Object.keys(action)[0]) {
         case "ini":
             return action.ini;
         case "new":
             const { ship, alliance } = action.new;
             return { ...state, [ship]: alliance }
+        case "add":
+            return { ...state, [action.add]: [] }
+        default:
+            return state;
     }
 }
 


### PR DESCRIPTION
If you added a new ship in search, and we didn't get a `new` action back (say it doesn't come in immediately, or for whatever reason it tells the back-end there's no apps) then it gives us an `add` action to add the ship without any apps.

`useReducer` apparently does not like undefined handlers, because we would then pass this action to `useReducer`, which would do nothing with it, inadvertently setting the value for our internal allies store to `undefined`.

This being set to `undefined` would then produce a false negative when searching subsequent ships, causing us to poke them to set up an allies + treaties relationship, which *itself* would produce `[]` (no apps) due to back-end subscription logic when trying to resubscribe to a pre-existing wire. 

Because we would then have that ship in our allies again, we would always return `[]` even on subsequent starts of the Scene session.

Some of this is out of our scope, but I am pretty sure this fixes the biggest Scene-specific issue.