### PR TITLE
Launchpad: unhide grid

### DIFF
--- a/src/components/Screen/Launchpad.js
+++ b/src/components/Screen/Launchpad.js
@@ -20,7 +20,6 @@ export default function Launchpad({
           .sort((a, b) =>
             a[1].title.toLowerCase().localeCompare(b[1].title.toLowerCase())
           )
-          .filter((e) => e[0] !== "garden")
           .map(([desk, charge]) => (
             <div
               key={desk}


### PR DESCRIPTION
This is in the tickets, but it is a bit quirky — what's the intended purpose of this? 

Right now all the grid tiles open in an external browser outside the desktop, because they're `target="_blank"` links that aren't strongly standardised. 

If you want this to open each grid tile in a floating window like everything else, we have to write some handlers to catch those links, which is a little odd since we already have a launchpad.