### PR TITLE
launchpad: fix app search dismissing the launchpad

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -80,21 +80,19 @@ function App() {
     ipcRenderer.on('deepLink', deepLinkListener);
     return () => ipcRenderer.removeListener('deepLink', deepLinkListener);
   }, []);
-
+  useClickOutside([
+    { current: document.getElementById('notifications') },
+    { current: document.getElementById('notifications-toggle') },
+  ], () => setShowNotifs(false));
+  useClickOutside([
+    { current: document.getElementById('hamburger') },
+    { current: document.getElementById('hamburger-toggle') },
+  ], () => setShowHamburger(false));
   useClickOutside(
-    ['launchpad', 'dock'],
-    () => setLaunchOpen(false)
-  );
-  useClickOutside(
-    ['notifications', 'notifications-toggle'],
-    () => setShowNotifs(false)
-  );
-  useClickOutside(
-    ['hamburger', 'hamburger-toggle'],
-    () => setShowHamburger(false)
-  );
-  useClickOutside(
-    ['planet-menu', 'planet-menu-toggle'],
+    [
+      { current: document.getElementById('planet-menu') },
+      { current: document.getElementById('planet-menu-toggle') },
+    ],
     () => setShowPlanetMenu(false)
   );
 

--- a/src/components/Screen/Launchpad.js
+++ b/src/components/Screen/Launchpad.js
@@ -1,4 +1,6 @@
 import cn from "classnames";
+import { useRef } from "react";
+import { useOutsideAlerter } from "../../lib/hooks";
 
 export default function Launchpad({
   apps,
@@ -6,13 +8,16 @@ export default function Launchpad({
   focusByCharge,
   launchOpen,
 }) {
+
+  const wrapperRef = useRef(null);
+  useOutsideAlerter(wrapperRef, () => launchOpen.set(false));
   return (
     <div
-      id="launchpad"
       className={cn(
         "bg-[rgba(0,0,0,0.7)] shadow-md shadow-[rgba(0,0,0,0.1)] w-full h-full max-w-[1024px] max-h-[80vh] z-[1000] rounded-xl m-4 flex flex-col items-center justify-center backdrop-blur-sm transition-all ease-in-out p-6 grow",
         { "opacity-0 fade-in": launchOpen.value, invisible: !launchOpen.value }
       )}
+      ref={wrapperRef}
     >
       {children}
       <div className="grow overflow-y-auto grid md:grid-cols-3 xl:grid-cols-4 gap-8">

--- a/src/lib/hooks.js
+++ b/src/lib/hooks.js
@@ -1,22 +1,20 @@
 import { useEffect } from "react";
 
-export const useClickOutside = (ids, callback) => {
-  if (!Array.isArray(ids) || !ids.every((id) => typeof id === "string")) {
-    throw new Error("useClickOutside requires an array of ids");
+export const useClickOutside = (parentRefs, callback) => {
+  if (!Array.isArray(parentRefs)) {
+    throw new Error('useClickOutside requires an array of parentRefs');
   }
 
   useEffect(() => {
-    const handleClickOutside = (ev) => {
-      if (
-        ids.every((id) => !document.getElementById(id)?.contains?.(ev.target))
-      ) {
+    const handleClickOutside = ev => {
+      if (parentRefs.every(r => !r.current.contains(ev.target))) {
         callback();
       }
-    };
-    document.addEventListener("click", handleClickOutside);
-    return () => document.removeEventListener("click", handleClickOutside);
-  }, [ids, callback]);
-};
+    }
+    document.addEventListener('click', handleClickOutside);
+    return () => document.removeEventListener('click', handleClickOutside);
+  }, [parentRefs, callback]);
+}
 
 export function useOutsideAlerter(ref, callback) {
   useEffect(() => {
@@ -25,7 +23,7 @@ export function useOutsideAlerter(ref, callback) {
      */
     function handleClickOutside(event) {
       if (ref.current && !ref.current.contains(event.target)) {
-        callback();
+        callback()
       }
     }
     // Bind the event listener


### PR DESCRIPTION
Basically a bunch of reverts. I am curious about the history here.

- Reverts our hooks to use refs, not ids. 

React uses refs because it has a Shadow DOM that is parallel, but _separate_, from the DOM tree, and it uses this shadow DOM to track what to render when, as well as the current location of all nodes. Refs have a `current` property, that corresponds to the DOM node, when we declare the connection between that node and React's node. 

By making our hooks attach to ids, we are hoping the id in question exists at runtime, creating event handlers to references that may not exist, and are tracked in parallel outside of React.

This creates a fun situation where we create event handlers before React has drawn the id to the page, meaning we are tracking clicks on undefined references.

Because the commit in question is also just attaching to ids, but on runtime, it should be changed, but at least works, so I'm leaving it in place for now.

- Reverts the Launchpad dismiss behaviour to the old one.

What was the issue that #31 was fixing? Launchpad dismissal worked then, and it works now — and dismissing the launchpad when you *search* is by far worse.