### PR TITLE
search: add sigil spinner when waiting on app results

### DIFF
--- a/src/components/Screen/Search.js
+++ b/src/components/Screen/Search.js
@@ -105,7 +105,9 @@ const Prompt = ({
               !allies.value?.[siggedAlly]?.length) && (
               <div className="p-4 text-xs text-center">
                 {loading ? (
-                  <Sigil patp={siggedAlly} size="48" color="black" className="animate-spin inline-block" />
+                  siggedAlly.length <= 14
+                    ? <Sigil patp={siggedAlly} size="48" color="black" className="animate-spin inline-block" />
+                    : <p>Checking {siggedAlly}... </p>
                 ) : (<>
                   No apps are available from {siggedAlly}.<br />
                   <span>Press Enter to search again.</span>

--- a/src/components/Screen/Search.js
+++ b/src/components/Screen/Search.js
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import ob from "urbit-ob";
 import { api } from "../../state/api";
 import { getTreaties } from "../../state/treaties";
+import Sigil from '../../components/sigil';
 
 export default function Search({ allies, treaties, apps }) {
   const [query, setQuery] = useState("");
@@ -103,12 +104,12 @@ const Prompt = ({
             (!allies.value?.[siggedAlly] ||
               !allies.value?.[siggedAlly]?.length) && (
               <p className="p-4 text-xs text-center">
-                No apps are available from {siggedAlly}.
-                <br />
                 {loading ? (
-                  <span>Loading...</span>
-                ) : (
+                  <Sigil patp={siggedAlly} size="48" className="animate-spin" />
+                ) : (<>
+                  No apps are available from {siggedAlly}.<br />
                   <span>Press Enter to search again.</span>
+                </>
                 )}
               </p>
             )}

--- a/src/components/Screen/Search.js
+++ b/src/components/Screen/Search.js
@@ -103,15 +103,15 @@ const Prompt = ({
             ob.isValidPatp(siggedAlly) &&
             (!allies.value?.[siggedAlly] ||
               !allies.value?.[siggedAlly]?.length) && (
-              <p className="p-4 text-xs text-center">
+              <div className="p-4 text-xs text-center">
                 {loading ? (
-                  <Sigil patp={siggedAlly} size="48" className="animate-spin" />
+                  <Sigil patp={siggedAlly} size="48" color="black" className="animate-spin inline-block" />
                 ) : (<>
                   No apps are available from {siggedAlly}.<br />
                   <span>Press Enter to search again.</span>
                 </>
                 )}
-              </p>
+              </div>
             )}
 
           {!currentApp.value?.desk &&

--- a/src/components/sigil.js
+++ b/src/components/sigil.js
@@ -12,14 +12,14 @@ export const foregroundFromBackground = (background) => {
     return whiteBrightness - brightness < 50 ? "black" : "white";
 };
 
-export const Sigil = ({ patp, size, color = "#24201E", icon }) => {
+export const Sigil = ({ patp, size, color = "#24201E", icon, className = "" }) => {
     if (patp.length > 14) {
         return <div />;
     }
     const foreground = foregroundFromBackground(color);
     return (
         <div
-            className={icon ? "p-1" : ""}
+            className={icon ? "p-1 " + className : className}
             style={{ backgroundColor: icon ? color || "black" : "transparent" }}
         >
             {sigil({


### PR DESCRIPTION
Adds a spinner in the loading state instead of just `Loading...`. We use the `siggedAlly` as the sigil when searching for their apps.