### PR TITLE
electron.js: fix typo

### DIFF
--- a/public/electron.js
+++ b/public/electron.js
@@ -189,9 +189,9 @@ if (!gotTheLock) {
         installExtension(REACT_DEVELOPER_TOOLS)
         setupLocalFilesNormalizerProxy();
         // check once on startup and then again every half hour
-        autoUpdater.addEventListener('update-downloaded',
-            () => ipcMain.send('update-downloaded'));
         autoUpdater.checkForUpdatesAndNotify();
+        app.addEventListener('update-downloaded',
+            () => ipcMain.send('update-downloaded'));
         setInterval(() => autoUpdater.checkForUpdatesAndNotify(), 1800000);
     });
     app.on('ready', async () => {


### PR DESCRIPTION
Adding an event listener to the auto-updater (not a function) made everything beneath it fail, including the check for updates.

Now it gets and downloads the update (with a desktop notification), but we're not applying it because the code isn't signed.

<img width="970" alt="Screenshot 2023-01-30 at 6 23 30 PM" src="https://user-images.githubusercontent.com/20846414/215646478-0fc41fc3-76e8-4da0-a0b9-20ed4559fb4a.png">
