### PR TITLE
App: handle Talk links from Groups

### DIFF
--- a/public/electron.js
+++ b/public/electron.js
@@ -44,7 +44,7 @@ function createWindow(dl_url) {
     // Open external links in other browsers (i.e. target="_blank").
     const ses = mainWindow.webContents.session;
     mainWindow.webContents.setWindowOpenHandler(({ url }) => {
-        if (url.includes(("/apps/talk"))) {
+        if (url.includes(("/apps/talk")) || url.includes(("/apps/groups"))) {
             mainWindow.webContents.executeJavaScript(`window.scene.linkToWindow("${url}")`);
             return {
                 action: "deny"

--- a/public/electron.js
+++ b/public/electron.js
@@ -44,7 +44,16 @@ function createWindow(dl_url) {
     // Open external links in other browsers (i.e. target="_blank").
     const ses = mainWindow.webContents.session;
     mainWindow.webContents.setWindowOpenHandler(({ url }) => {
-        return shell.openExternal(url)
+        if (url.includes(("/apps/talk"))) {
+            mainWindow.webContents.executeJavaScript(`window.scene.linkToWindow("${url}")`);
+            return {
+                action: "deny"
+            }
+        }
+        shell.openExternal(url)
+        return {
+            action: "deny"
+        }
     })
 
     getAuth(dl_url).then((res) => {

--- a/src/App.js
+++ b/src/App.js
@@ -18,6 +18,7 @@ import PlanetMenu from './components/PlanetMenu';
 import { useClickOutside } from './lib/hooks';
 import { setAuth } from './lib/auth';
 import { setBackgroundImage } from './lib/background';
+import { incomingLinkToWindow } from "./lib/window";
 const { ipcRenderer } = require("electron");
 
 function App() {
@@ -84,6 +85,23 @@ function App() {
     ipcRenderer.on('deepLink', deepLinkListener);
     return () => ipcRenderer.removeListener('deepLink', deepLinkListener);
   }, []);
+
+  useEffect(() => {
+    window.scene.linkToWindow = (link) => incomingLinkToWindow(link, {
+      apps: {
+        value: apps
+      },
+      windows: {
+        set: setWindows,
+        value: windows
+      },
+      selectedWindow: {
+        set: setSelectedWindow,
+        value: selectedWindow
+      }
+    })
+
+  }, [apps, windows, setWindows, selectedWindow, setSelectedWindow])
 
   useClickOutside([
     { current: document.getElementById('notifications') },

--- a/src/lib/window.js
+++ b/src/lib/window.js
@@ -8,7 +8,7 @@ export function incomingLinkToWindow(link, { apps, windows, selectedWindow }) {
             windows.set([charge, ...windows.value.filter((e) => e.desk !== desk)]);
             selectedWindow.set([charge, ...selectedWindow.value.filter((e) => e.desk !== desk)])
         } else {
-            windows.set([...windows.value, charge])
+            windows.set([charge, ...windows.value])
             selectedWindow.set([charge, ...selectedWindow.value])
         }
     }

--- a/src/lib/window.js
+++ b/src/lib/window.js
@@ -1,0 +1,16 @@
+export function incomingLinkToWindow(link, { apps, windows, selectedWindow }) {
+    const splitUrl = link.split("/");
+    const desk = splitUrl[splitUrl.indexOf("apps") + 1];
+    const remainderUrl = splitUrl.slice(splitUrl.indexOf(desk)).join("/");
+    if (desk in apps?.value?.charges) {
+        const charge = { ...apps.value.charges[desk], ...{ href: { glob: { base: remainderUrl } } } };
+        if (windows.value.some((e) => e.desk === desk)) {
+            windows.set([charge, ...windows.value.filter((e) => e.desk !== desk)]);
+            selectedWindow.set([charge, ...selectedWindow.value.filter((e) => e.desk !== desk)])
+        } else {
+            windows.set([...windows.value, charge])
+            selectedWindow.set([charge, ...selectedWindow.value])
+        }
+    }
+    return false
+}


### PR DESCRIPTION
If a link with `target="_blank"` has `/apps/talk`, we slice it up and pass it into a function that hooks into React state, makes a fake charge with the permalink set as its "base" and then sets the Talk window (if it's open) to that window; if no window is open for Talk, it opens one to the permalink.