### PR TITLE
package.json: universal binaries for mac

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,9 +16,11 @@ jobs:
 
       - name: Install Node, NPM, Yarn
         uses: actions/setup-node@v3
+        with:
+          node-version: 16
       
       - name: Build/release Scene
-        uses: samuelmeuli/action-electron-builder@v1
+        uses: Yan-Jobs/action-electron-builder@v1.7.0
         with:
           github_token: ${{ secrets.github_token }}
 

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "eject": "react-scripts eject",
     "electron:start": "concurrently -k \"cross-env BROWSER=none yarn run start start\" \"wait-on http://localhost:3000 && electronmon . \"",
     "electron:package:mac:nocs": "cross-env NODE_ENV=production yarn run build && electron-builder -m -c.extraMetadata.main=build/electron.js -c.mac.identity=null",
-    "electron:package:mac": "cross-env NODE_ENV=production yarn run build && electron-builder -m --universal -c.extraMetadata.main=build/electron.js",
+    "electron:package:mac": "cross-env NODE_ENV=production yarn run build && electron-builder -m -c.extraMetadata.main=build/electron.js",
     "electron:package:win": "cross-env NODE_ENV=production yarn run build && electron-builder -w -c.extraMetadata.main=build/electron.js",
     "electron:package:linux": "cross-env NODE_ENV=production yarn run build && electron-builder -l -c.extraMetadata.main=build/electron.js",
     "electron:package:all": "cross-env node_env=production yarn run build && electron-builder -m -w -l -c.extraMetadata.main=build/electron.js"

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "eject": "react-scripts eject",
     "electron:start": "concurrently -k \"cross-env BROWSER=none yarn run start start\" \"wait-on http://localhost:3000 && electronmon . \"",
     "electron:package:mac:nocs": "cross-env NODE_ENV=production yarn run build && electron-builder -m -c.extraMetadata.main=build/electron.js -c.mac.identity=null",
-    "electron:package:mac": "cross-env NODE_ENV=production yarn run build && electron-builder -m -c.extraMetadata.main=build/electron.js",
+    "electron:package:mac": "cross-env NODE_ENV=production yarn run build && electron-builder -m --universal -c.extraMetadata.main=build/electron.js",
     "electron:package:win": "cross-env NODE_ENV=production yarn run build && electron-builder -w -c.extraMetadata.main=build/electron.js",
     "electron:package:linux": "cross-env NODE_ENV=production yarn run build && electron-builder -l -c.extraMetadata.main=build/electron.js",
     "electron:package:all": "cross-env node_env=production yarn run build && electron-builder -m -w -l -c.extraMetadata.main=build/electron.js"


### PR DESCRIPTION
This flag grabs both precompiled Electrons and zips them into the final binary. As a result this makes the app itself about 560mb, which is rather high; the alternative is to offer separate architectures, but I sense the UX cost is already high enough ... ?