### PR TITLE
dock: focus without manipulating window array

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -223,7 +223,7 @@ function App() {
             apps={apps}
             launchOpen={{ value: launchOpen, set: setLaunchOpen }}
             windows={{ value: windows, set: setWindows }}
-            focusByCharge={focusByCharge}
+            selectedWindow={{ value: selectedWindow, set: setSelectedWindow }}
           />
         </Screen>
       </div>

--- a/src/App.js
+++ b/src/App.js
@@ -223,6 +223,7 @@ function App() {
             apps={apps}
             launchOpen={{ value: launchOpen, set: setLaunchOpen }}
             windows={{ value: windows, set: setWindows }}
+            hiddenWindow={{ value: hiddenWindow, set: setHiddenWindow }}
             selectedWindow={{ value: selectedWindow, set: setSelectedWindow }}
           />
         </Screen>

--- a/src/components/Dock.js
+++ b/src/components/Dock.js
@@ -1,7 +1,7 @@
 import Tippy from "@tippyjs/react";
 import LaunchpadIcon from "./icons/launchpad";
 
-export default function Dock({ windows, selectedWindow, launchOpen }) {
+export default function Dock({ windows, selectedWindow, hiddenWindow, launchOpen }) {
   return (
     <div
       id="dock"
@@ -20,6 +20,7 @@ export default function Dock({ windows, selectedWindow, launchOpen }) {
                   charge,
                   ...selectedWindow.value.filter((e) => e.desk !== charge.desk),
                 ])
+                hiddenWindow.set(hiddenWindow.value.filter(i => i !== charge));
               }}
             >
               {charge?.image && (

--- a/src/components/Dock.js
+++ b/src/components/Dock.js
@@ -1,7 +1,7 @@
 import Tippy from "@tippyjs/react";
 import LaunchpadIcon from "./icons/launchpad";
 
-export default function Dock({ windows, focusByCharge, launchOpen }) {
+export default function Dock({ windows, selectedWindow, launchOpen }) {
   return (
     <div
       id="dock"
@@ -16,7 +16,10 @@ export default function Dock({ windows, focusByCharge, launchOpen }) {
               key={charge.title}
               onClick={() => {
                 launchOpen.set(false);
-                focusByCharge(charge);
+                selectedWindow.set([
+                  charge,
+                  ...selectedWindow.value.filter((e) => e.desk !== charge.desk),
+                ])
               }}
             >
               {charge?.image && (

--- a/src/components/Screen.js
+++ b/src/components/Screen.js
@@ -22,7 +22,7 @@ export default function Screen({
       {children}
       {windows.value.map((win, index) => (
         <Window
-          key={win.title}
+          key={win.desk}
           win={win}
           launchOpen={launchOpen}
           index={index}

--- a/src/state/hark.js
+++ b/src/state/hark.js
@@ -46,7 +46,6 @@ const useHarkState = create((set, get) => ({
             app: 'hark',
             path: '/ui',
             event: (event) => {
-                console.log(event, get().carpet);
                 const { retrieve } = get();
                 retrieve();
             },


### PR DESCRIPTION
Stray bug where focusing on an app from the dock could wipe the window entirely, post #52. This seems due to shuffling the window array, so we just rearrange selected and hidden window arrays.