### PR TITLE
Notifications: fix clear producing false negative

### DIFF
--- a/src/components/Notifications.js
+++ b/src/components/Notifications.js
@@ -14,7 +14,7 @@ export default function Notifications({ visible, charges, focusByCharge }) {
 
     const latestYarnFilter = (e) => {
         if (latestYarn) {
-            return e[0]?.latest > latestYarn
+            return e?.latest > latestYarn
         }
         else return true
     };
@@ -31,7 +31,10 @@ export default function Notifications({ visible, charges, focusByCharge }) {
                         color: text,
                         backgroundColor: header
                     }}
-                    onClick={() => setLatestYarn(notifications[0]?.latest || null)}
+                    onClick={() => {
+                        window.localStorage.setItem('tirrel-desktop-latest-yarn', notifications[0]?.latest || null)
+                        setLatestYarn(notifications[0]?.latest || null)
+                    }}
                 >
                     Clear
                 </button>}


### PR DESCRIPTION
Our filter for latest yarn cleared improperly accessed its children producing `undefined`, meaning once you hit 'clear' no notifications would be rendered. Since we also weren't writing the clear to localstorage, this only persisted for the session. We do the comparison properly now and also save to localstorage.