### PR TITLE
App: pull all window, widget props into contexts

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -15,13 +15,14 @@ import Launchpad from './components/Screen/Launchpad';
 import Search from './components/Screen/Search';
 import HamburgerMenu from './components/HamburgerMenu';
 import PlanetMenu from './components/PlanetMenu';
-import { useClickOutside } from './lib/hooks';
 import { setAuth } from './lib/auth';
 import { setBackgroundImage, getColors } from './lib/background';
 import { incomingLinkToWindow } from "./lib/window";
 const { ipcRenderer } = require("electron");
 
 export const ThemeContext = createContext();
+export const WindowContext = createContext();
+
 
 function App() {
   const { bg, pal } = useLoaderData();
@@ -32,12 +33,8 @@ function App() {
   const [hiddenWindow, setHiddenWindow] = useState([]);
   const [selectedWindow, setSelectedWindow] = useState([]);
   const [launchOpen, setLaunchOpen] = useState(false);
-  const [showNotifs, setShowNotifs] = useState(false);
   const [showNativeNotifs, setShowNativeNotifs] = useState(false);
-  const [showHamburger, setShowHamburger] = useState(false);
-  const [showPlanetMenu, setShowPlanetMenu] = useState(false);
   const [updateAvailable, setUpdateAvailable] = useState();
-  const [appVersion, setAppVersion] = useState();
   const [bgImage, setBgImage] = useState(bg);
   const [palette, setPalette] = useState(pal);
 
@@ -63,8 +60,6 @@ function App() {
 
       window.scene.handleUpdateDownloaded(() => setUpdateAvailable(true));
 
-      const version = await window.scene.queryVersion();
-      setAppVersion(version);
     }
 
     init();
@@ -119,24 +114,6 @@ function App() {
 
   }, [apps, windows, setWindows, selectedWindow, setSelectedWindow])
 
-  // Listeners for prompts and menus to dismiss them clicking on something else.
-
-  useClickOutside([
-    { current: document.getElementById('notifications') },
-    { current: document.getElementById('notifications-toggle') },
-  ], () => setShowNotifs(false));
-  useClickOutside([
-    { current: document.getElementById('hamburger') },
-    { current: document.getElementById('hamburger-toggle') },
-  ], () => setShowHamburger(false));
-  useClickOutside(
-    [
-      { current: document.getElementById('planet-menu') },
-      { current: document.getElementById('planet-menu-toggle') },
-    ],
-    () => setShowPlanetMenu(false)
-  );
-
   // Focus or spawn a window, shuffling our state
   // based on whether a notification or a tile is clicked related to the app.
   const focusByCharge = useCallback((charge, channel) => {
@@ -164,70 +141,61 @@ function App() {
 
   return (
     <ThemeContext.Provider value={palette}>
-      <div
-        className="bg-[#e4e4e4] h-screen w-screen flex flex-col absolute overflow-hidden"
-        style={{
-          backgroundImage: `url(${bgImage.startsWith('hallstatt') ? '' : 'file://'}${encodeURI(bgImage)})`,
-          backgroundSize: 'cover',
-        }}>
-        <HeaderBar
-          selectedWindow={{ value: selectedWindow, set: setSelectedWindow }}
-          windows={{ value: windows, set: setWindows }}
-          toggleNotifs={() => {
-            useHarkState.getState().sawSeam({ all: null });
-            setShowNotifs(a => !a)
-          }}
-          toggleHamburger={() => setShowHamburger(a => !a)}
-          togglePlanetMenu={() => setShowPlanetMenu(a => !a)}
-          updateAvailable={updateAvailable}
-        >
-          <PlanetMenu
-            visible={{ value: showPlanetMenu, set: setShowPlanetMenu }}
-            updateAvailable={updateAvailable}
-            appVersion={appVersion}
-          />
-          <HamburgerMenu
-            visible={{ value: showHamburger, set: setShowHamburger }}
-            setBgImage={setBgImage}
-            nativeNotifs={{
-              value: showNativeNotifs,
-              set: next => {
-                setShowNativeNotifs(next);
-                window.localStorage.setItem('nativeNotifs', JSON.stringify(next))
-              }
-            }}
-          />
-          <Notifications
-            visible={{ value: showNotifs, set: setShowNotifs }}
-            charges={apps.charges}
-            focusByCharge={focusByCharge}
-          />
-        </HeaderBar>
-        <Screen
-          hiddenWindow={{ value: hiddenWindow, set: setHiddenWindow }}
-          selectedWindow={{ value: selectedWindow, set: setSelectedWindow }}
-          launchOpen={{ value: launchOpen, set: setLaunchOpen }}
-          windows={{ value: windows, set: setWindows }}
-        >
-          <Launchpad
-            apps={apps}
-            launchOpen={{ value: launchOpen, set: setLaunchOpen }}
-            focusByCharge={focusByCharge}>
-            <Search
-              allies={{ value: allies, set: setAllies }}
-              treaties={{ value: treaties, set: setTreaties }}
-              apps={apps}
+      <WindowContext.Provider value={{
+        selectedWindow: {
+          value: selectedWindow,
+          set: setSelectedWindow
+        },
+        windows: {
+          value: windows,
+          set: setWindows
+        },
+        hiddenWindow: {
+          value: hiddenWindow,
+          set: setHiddenWindow
+        },
+        launchOpen: {
+          value: launchOpen,
+          set: setLaunchOpen
+        }
+      }}>
+        <div
+          className="bg-[#e4e4e4] h-screen w-screen flex flex-col absolute overflow-hidden"
+          style={{
+            backgroundImage: `url(${bgImage.startsWith('hallstatt') ? '' : 'file://'}${encodeURI(bgImage)})`,
+            backgroundSize: 'cover',
+          }}>
+          <HeaderBar updateAvailable={updateAvailable}>
+            <PlanetMenu updateAvailable={updateAvailable} />
+            <HamburgerMenu
+              setBgImage={setBgImage}
+              nativeNotifs={{
+                value: showNativeNotifs,
+                set: next => {
+                  setShowNativeNotifs(next);
+                  window.localStorage.setItem('nativeNotifs', JSON.stringify(next))
+                }
+              }}
             />
-          </Launchpad>
-          <Dock
-            apps={apps}
-            launchOpen={{ value: launchOpen, set: setLaunchOpen }}
-            windows={{ value: windows, set: setWindows }}
-            hiddenWindow={{ value: hiddenWindow, set: setHiddenWindow }}
-            selectedWindow={{ value: selectedWindow, set: setSelectedWindow }}
-          />
-        </Screen>
-      </div>
+            <Notifications
+              charges={apps.charges}
+              focusByCharge={focusByCharge}
+            />
+          </HeaderBar>
+          <Screen>
+            <Launchpad
+              apps={apps}
+              focusByCharge={focusByCharge}>
+              <Search
+                allies={{ value: allies, set: setAllies }}
+                treaties={{ value: treaties, set: setTreaties }}
+                apps={apps}
+              />
+            </Launchpad>
+            <Dock apps={apps} />
+          </Screen>
+        </div>
+      </WindowContext.Provider>
     </ThemeContext.Provider>
   );
 }

--- a/src/components/Dock.js
+++ b/src/components/Dock.js
@@ -1,7 +1,11 @@
 import Tippy from "@tippyjs/react";
+import { useContext } from "react";
+import { WindowContext } from "../App";
 import LaunchpadIcon from "./icons/launchpad";
 
-export default function Dock({ windows, selectedWindow, hiddenWindow, launchOpen }) {
+export default function Dock() {
+  const { windows, selectedWindow, hiddenWindow, launchOpen } = useContext(WindowContext);
+
   return (
     <div
       id="dock"

--- a/src/components/HamburgerMenu.js
+++ b/src/components/HamburgerMenu.js
@@ -1,9 +1,11 @@
 import { useState, useContext } from 'react';
 import { set, whiteOrBlack } from '../lib/background';
 import { ThemeContext } from "../App"
+import { WidgetContext } from './HeaderBar';
 
 const HamburgerMenu = props => {
-  const { nativeNotifs, setBgImage, visible } = props;
+  const { nativeNotifs, setBgImage } = props;
+  const { showHamburger: visible } = useContext(WidgetContext);
 
   return (
     <div

--- a/src/components/HeaderBar.js
+++ b/src/components/HeaderBar.js
@@ -1,20 +1,19 @@
 import { sigil, reactRenderer } from '@tlon/sigil-js';
 import ob from 'urbit-ob'
-import { useState, useRef } from 'react';
+import { useState, useRef, useContext, createContext } from 'react';
 import { useNotifications } from "./../lib/useNotifications"
 import { api } from "../state/api";
-import { useOutsideAlerter } from '../lib/hooks';
+import { useOutsideAlerter, useClickOutside } from '../lib/hooks';
 import HamburgerIcon from './icons/hamburger';
 import BellIcon from './icons/bell';
 import { docketUninstall } from '@urbit/api';
 import { getAuth } from '../lib/auth';
+import { WindowContext } from '../App';
+import useHarkState from "../state/hark";
+
+export const WidgetContext = createContext();
 
 export default function HeaderBar({
-  selectedWindow,
-  windows,
-  toggleHamburger,
-  toggleNotifs,
-  togglePlanetMenu,
   updateAvailable,
   children
 }) {
@@ -22,15 +21,50 @@ export default function HeaderBar({
   const [windowMenu, setWindowMenu] = useState(false);
   const windowMenuRef = useRef(null);
   useOutsideAlerter(windowMenuRef, () => setWindowMenu(false));
+  const { selectedWindow, windows } = useContext(WindowContext);
   const { count } = useNotifications();
+  const [showNotifs, setShowNotifs] = useState(false);
+  const [showHamburger, setShowHamburger] = useState(false);
+  const [showPlanetMenu, setShowPlanetMenu] = useState(false);
+
+  // Listeners for prompts and menus to dismiss them clicking on something else.
+  useClickOutside([
+    { current: document.getElementById('notifications') },
+    { current: document.getElementById('notifications-toggle') },
+  ], () => setShowNotifs(false));
+  useClickOutside([
+    { current: document.getElementById('hamburger') },
+    { current: document.getElementById('hamburger-toggle') },
+  ], () => setShowHamburger(false));
+  useClickOutside(
+    [
+      { current: document.getElementById('planet-menu') },
+      { current: document.getElementById('planet-menu-toggle') },
+    ],
+    () => setShowPlanetMenu(false)
+  );
+
 
   return (
-    <>
+    <WidgetContext.Provider value={{
+      showNotifications: {
+        set: setShowNotifs,
+        value: showNotifs
+      },
+      showHamburger: {
+        set: setShowHamburger,
+        value: showHamburger
+      },
+      showPlanetMenu: {
+        set: setShowPlanetMenu,
+        value: showPlanetMenu
+      }
+    }}>
       <div className="text-white w-full bg-[rgba(0,0,0,0.7)] backdrop-blur-sm flex justify-between items-center min-h-[2.25rem] px-4 cursor-default border-b border-[rgba(0,0,0,0.15)] z-[9999] relative">
         <div className="flex" style={{ gap: '1rem' }}>
           <button
             id="planet-menu-toggle"
-            onClick={togglePlanetMenu}
+            onClick={() => setShowPlanetMenu((a) => !a)}
             className={`border-none rounded-lg px-2 bg-[#FFF3] text-white flex-1 flex flex-column justify-center items-center ${updateAvailable ? 'bg-rose-400' : ''}`}>
             {sigil({
               patp: (ob.isValidPatp(`~${patp}`) && (patp.length <= 13)) ? `~${patp}` : '~zod',
@@ -71,19 +105,22 @@ export default function HeaderBar({
           <button
             id="notifications-toggle"
             className={`border-none text-white flex-1 flex flex-column justify-center items-center ${count > 0 ? 'bg-rose-400' : ''}`}
-            onClick={toggleNotifs}>
+            onClick={() => {
+              useHarkState.getState().sawSeam({ all: null });
+              setShowNotifs(a => !a)
+            }}>
             <BellIcon />
           </button>
 
           <button
             id="hamburger-toggle"
             className="border-none text-white flex-1 flex flex-column justify-center items-center"
-            onClick={toggleHamburger}>
+            onClick={() => setShowHamburger(a => !a)}>
             <HamburgerIcon />
           </button>
         </div>
       </div>
       {children}
-    </>
+    </WidgetContext.Provider>
   )
 }

--- a/src/components/Notifications.js
+++ b/src/components/Notifications.js
@@ -3,8 +3,10 @@ import { useNotifications } from "../lib/useNotifications";
 import { useContext, useState } from 'react';
 import { ThemeContext } from '../App';
 import { whiteOrBlack } from '../lib/background';
+import { WidgetContext } from './HeaderBar';
 
-export default function Notifications({ visible, charges, focusByCharge }) {
+export default function Notifications({ charges, focusByCharge }) {
+    const { showNotifications: visible } = useContext(WidgetContext);
     const { notifications, count } = useNotifications();
     const [latestYarn, setLatestYarn] = useState(window.localStorage.getItem('tirrel-desktop-latest-yarn'));
 

--- a/src/components/PlanetMenu.js
+++ b/src/components/PlanetMenu.js
@@ -1,11 +1,25 @@
 import cn from "classnames";
 import { getAuth, clearAuth } from "../lib/auth";
-import { useContext } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import { whiteOrBlack } from '../lib/background';
 import { ThemeContext } from "../App"
+import { WidgetContext } from "./HeaderBar";
 
 export default function PlanetMenu(props) {
-  const { visible, updateAvailable, appVersion } = props;
+  const { updateAvailable } = props;
+  const { showPlanetMenu: visible } = useContext(WidgetContext);
+  const [appVersion, setAppVersion] = useState("");
+
+  useEffect(() => {
+    const getVersion = async () => {
+      const version = await window.scene.queryVersion();
+      setAppVersion(version);
+    }
+    if (appVersion === "") {
+      getVersion();
+    }
+  }, [appVersion])
+
   const { ship } = getAuth();
   return (
     <div

--- a/src/components/Screen.js
+++ b/src/components/Screen.js
@@ -1,13 +1,13 @@
 import Window from "./Screen/Window";
 import { screenPadding } from '../lib/constants';
+import { useContext } from "react";
+import { WindowContext } from "../App";
 
 export default function Screen({
-  windows,
-  selectedWindow,
-  hiddenWindow,
-  launchOpen,
   children,
 }) {
+  const { windows, selectedWindow, hiddenWindow, launchOpen } = useContext(WindowContext);
+
   return (
     <div
       className="grow flex flex-col justify-end items-center"

--- a/src/components/Screen/Launchpad.js
+++ b/src/components/Screen/Launchpad.js
@@ -1,14 +1,16 @@
 import cn from "classnames";
 import LaunchpadTile from './LaunchpadTile';
-import { useRef } from "react";
+import { useContext, useRef } from "react";
 import { useOutsideAlerter } from "../../lib/hooks";
+import { WindowContext } from "../../App";
 
 export default function Launchpad({
   apps,
   children,
   focusByCharge,
-  launchOpen,
 }) {
+
+  const { launchOpen } = useContext(WindowContext);
 
   const wrapperRef = useRef(null);
   useOutsideAlerter(wrapperRef, () => launchOpen.set(false));


### PR DESCRIPTION
Fixes #38.

Uses contexts instead of props to simplify our top-level component significantly.

- `windows`, `selectedWindow`, `hiddenWindow` and `launchOpen` go into a `WindowContext`, which we then use instead of prop drilling.
- `showNotifs`, `showHamburger`, `showPlanetMenu` and `appVersion` are all tied specifically to the HeaderBar and its widgets, so they're moved to HeaderBar's state and passed into a `WidgetContext` for its children.

The intention is to make it more sustainable to add cross-cutting features in future while being less reliant on writing all our code in App.js. We can probably pull more code out, but this is a solid step.