### PR TITLE
Don't show menu at the top of the main window

### DIFF
--- a/public/electron.js
+++ b/public/electron.js
@@ -41,6 +41,9 @@ function createWindow(dl_url) {
         },
     });
 
+    //Disable the menu at the top of the window if not on macos
+    process.platform !== 'darwin' && mainWindow.setMenu(null);
+
     // Open external links in other browsers (i.e. target="_blank").
     const ses = mainWindow.webContents.session;
     mainWindow.webContents.setWindowOpenHandler(({ url }) => {


### PR DESCRIPTION
This is a change I made to my local build to remove the annoying (in my humble opinion) menu at the top of the main window.

I am using a tiling window manager so maybe I am biased, but I think it looks much better. Feel free to disregard if this is not helpful!